### PR TITLE
Deprecate remove_more_sentinel in favor of remove_sentinel, which allows better control over hiding tracebacks

### DIFF
--- a/graderutils/schemaobjects.py
+++ b/graderutils/schemaobjects.py
@@ -9,7 +9,7 @@ from graderutils import graderunittest
 SCHEMA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "schemas"))
 
 
-def build_schemas(version="v1_0"):
+def build_schemas(version="v1_1"):
     """
     Build all feedback schemas and the graderutils test_config schema.
     """

--- a/graderutils/schemas/test_config_v1_1.yaml
+++ b/graderutils/schemas/test_config_v1_1.yaml
@@ -1,5 +1,5 @@
 $schema: http://json-schema.org/draft-07/schema
-version: "1.0"
+version: "1.1"
 title: Test config
 type: object
 description: Graderutils runtime configuration file
@@ -39,7 +39,13 @@ properties:
           type: boolean
         remove_more_sentinel:
           description: |
-            If hide_tracebacks is given and true, continue removing traceback until this sentinel is found.
+            [Deprecated, use remove_sentinel instead] If hide_tracebacks is given and true, continue removing traceback until this sentinel is found.
+            Removes also the sentinel.
+          minLength: 1
+          type: string
+        remove_sentinel:
+          description: |
+            Removes traceback until this sentinel is found.
             Removes also the sentinel.
           minLength: 1
           type: string

--- a/graderutils/test_config.yaml
+++ b/graderutils/test_config.yaml
@@ -111,9 +111,9 @@ validation:
 #
 # AssertionError: True is not false : -1 is not a prime number, but your function says it is
 #
-# If remove_more_sentinel is given, then everything starting from the exception line ending at the sentinel, will also be removed.
+# If remove_sentinel is given, then all traceback until (including) the sentinel string, will be removed.
 #
-# e.g. with AssertionError and remove_more_sentinel [remove-stop]:
+# e.g. with AssertionError and remove_sentinel [remove-stop]:
 #
 # Traceback (most recent call last):
 #   File "local_tests.py", line 33, in test_is_prime_with_no_primes
@@ -138,8 +138,8 @@ format_tracebacks:
     - class_name: AssertionError
       hide_tracebacks: true
       hide_tracebacks_short_only: true
-      # Continue removing tracebacks until (including) this sentinel string
-      remove_more_sentinel: "[remove-stop]"
+      # Remove tracebacks until (including) this sentinel string
+      remove_sentinel: "[remove-stop]"
     # Default configuration, hide all tracebacks
     - class_name: '*'
       hide_tracebacks: true

--- a/graderutils/tracebackformat.py
+++ b/graderutils/tracebackformat.py
@@ -37,12 +37,12 @@ def _iter_redacted_lines(lines, remove_lines, replacement_string):
         yield line
 
 
-def hide_exception_traceback(output, exception_class_name, remove_more_sentinel=None, replacement_string=None):
+def hide_exception_traceback(output, exception_class_name, hide_tracebacks, remove_sentinel=None, replacement_string=None):
     """
     Find all tracebacks in output, caused by exceptions specified by exception_class_name and return a string where all traceback occurrences in traceback_string have been replaced with replacement_string.
     In other words, everything starting with 'Traceback (most recent call last)' up until the exception message is replaced.
 
-    If remove_more_sentinel is given, then even more is removed.
+    If remove_sentinel is given, then traceback until replacement_string is removed.
     E.g. with [remove-stop]:
     "AssertionError : True is not False : [remove-stop]no it isn't"
     turns into:
@@ -50,6 +50,8 @@ def hide_exception_traceback(output, exception_class_name, remove_more_sentinel=
 
     If exception_class_name is '*', all tracebacks are removed.
     """
+    cleaned_traceback_string = output
+
     traceback_header = "Traceback (most recent call last)"
     begin_traceback = re.compile('^' + re.escape(traceback_header))
     if exception_class_name == '*':
@@ -57,47 +59,48 @@ def hide_exception_traceback(output, exception_class_name, remove_more_sentinel=
     else:
         end_traceback = re.compile('^' + re.escape(exception_class_name))
 
-    # Find all lines that match the pattern range
+    if hide_tracebacks:
+        # Find all lines that match the pattern range
 
-    lines = output.splitlines(keepends=True)
+        lines = output.splitlines(keepends=True)
 
-    is_matching = False
-    # Pending match, pair of (start_index, line_count)
-    match = []
-    # Finalized matches to be removed, pairs of (start_index, line_count)
-    matches = []
+        is_matching = False
+        # Pending match, pair of (start_index, line_count)
+        match = []
+        # Finalized matches to be removed, pairs of (start_index, line_count)
+        matches = []
 
-    for lineno, line in enumerate(lines):
-        if is_matching:
-            if re.match(end_traceback, line):
-                # Fully matched one traceback
-                matches.append(tuple(match))
-                match = []
-                is_matching = False
+        for lineno, line in enumerate(lines):
+            if is_matching:
+                if re.match(end_traceback, line):
+                    # Fully matched one traceback
+                    matches.append(tuple(match))
+                    match = []
+                    is_matching = False
+                elif re.match(begin_traceback, line):
+                    # This match overlaps 2 traceback strings, and the first one is from an exception not specified by exception_class_name
+                    # Drop first match and start a new one from here
+                    match = [lineno, 1]
+                else:
+                    # Accumulate match with one line
+                    match[1] += 1
             elif re.match(begin_traceback, line):
-                # This match overlaps 2 traceback strings, and the first one is from an exception not specified by exception_class_name
-                # Drop first match and start a new one from here
+                # Found a traceback header, start accumulating traceback string
+                is_matching = True
                 match = [lineno, 1]
-            else:
-                # Accumulate match with one line
-                match[1] += 1
-        elif re.match(begin_traceback, line):
-            # Found a traceback header, start accumulating traceback string
-            is_matching = True
-            match = [lineno, 1]
 
-    # Replace matching line chunks with the replacement_string
-    cleaned_traceback_string = ''.join(_iter_redacted_lines(lines, iter(matches), replacement_string))
+        # Replace matching line chunks with the replacement_string
+        cleaned_traceback_string = ''.join(_iter_redacted_lines(lines, iter(matches), replacement_string))
 
     # Remove even more starting at the replacement string if a sentinel is given
-    if remove_more_sentinel:
+    if remove_sentinel:
         if replacement_string and not replacement_string.endswith('\n'):
             # Exception names will be on the same line with the last line of the replacement string, which starts the line
             begin_pattern_str = '^' + re.escape(replacement_string.splitlines()[-1]) + end_traceback.pattern[1:]
         else:
             # Exception names will start new lines immediately below the last line of the replacement string
             begin_pattern_str = end_traceback.pattern
-        remove_pattern = re.compile(begin_pattern_str + r'(.|[\r\n])*?' + re.escape(remove_more_sentinel), re.MULTILINE)
+        remove_pattern = re.compile(begin_pattern_str + r'(.|[\r\n])*?' + re.escape(remove_sentinel), re.MULTILINE)
         cleaned_traceback_string = re.sub(remove_pattern, '', cleaned_traceback_string)
 
     return cleaned_traceback_string
@@ -112,13 +115,25 @@ def clean_feedback(result_groups, config):
         for result in group["testResults"]:
             # Run all cleaning tasks for traceback
             for task in config:
-                if task.get("hide_tracebacks", False):
+                hide_tracebacks = task.get('hide_tracebacks', False)
+                remove_sentinel = task.get('remove_sentinel', '')
+                if hide_tracebacks or remove_sentinel:
                     # This task defines that exceptions from some class must be hidden
+
+                    # DEPRECATED:
+                    # remove_more_sentinel allowed for traceback removal only when hide_tracebacks was set to true.
+                    # remove_sentinel replaces the old remove_more_sentinel and it does not have the described limitation.
+                    # The new remove_sentinel does not change old behaviour of remove_more_sentinel.
+                    # Once next major version is released, delete the following two lines.
+                    if task.get("remove_more_sentinel", ''):
+                        remove_sentinel = task.get("remove_more_sentinel", '')
+
                     exception_class_name = task["class_name"].strip()
                     result["testOutput"] = hide_exception_traceback(
                         result["testOutput"],
                         exception_class_name,
-                        remove_more_sentinel=task.get("remove_more_sentinel", ''),
+                        hide_tracebacks=hide_tracebacks,
+                        remove_sentinel=remove_sentinel,
                         replacement_string=task.get("hide_tracebacks_replacement", '')
                     )
                     if not task.get("hide_tracebacks_short_only", False):
@@ -126,11 +141,24 @@ def clean_feedback(result_groups, config):
                         result["fullTestOutput"] = result["testOutput"]
         # Now for the full output from running the test suite
         for task in config:
-            if task.get("hide_tracebacks", False) and not task.get("hide_tracebacks_short_only", False):
+            hide_tracebacks = task.get("hide_tracebacks", False)
+            hide_tracebacks_short_only = task.get("hide_tracebacks_short_only", False)
+            if hide_tracebacks and not hide_tracebacks_short_only:
+                remove_sentinel = task.get("remove_sentinel", '')
+
+                # DEPRECATED:
+                # remove_more_sentinel allowed for traceback removal only when hide_tracebacks was set to true.
+                # remove_sentinel replaces the old remove_more_sentinel and it does not have the described limitation.
+                # The new remove_sentinel does not change old behaviour of remove_more_sentinel.
+                # Once next major version is released, delete the following two lines.
+                if task.get("remove_more_sentinel", ''):
+                    remove_sentinel = task.get("remove_more_sentinel", '')
+
                 exception_class_name = task["class_name"].strip()
                 group["fullOutput"] = hide_exception_traceback(
                     group["fullOutput"],
                     exception_class_name,
-                    remove_more_sentinel=task.get("remove_more_sentinel", ''),
+                    hide_tracebacks=hide_tracebacks,
+                    remove_sentinel=remove_sentinel,
                     replacement_string=task.get("hide_tracebacks_replacement", '')
                 )


### PR DESCRIPTION
# Description

These changes allow the use of `remove_sentinel` (previously `remove_more_sentinel`) in `test_config.yaml` without having to set `hide_tracebacks: true`, which would previously result in tracebacks in other tests being hidden, even if they do not contain the sentinel.

Essentially, allows hiding of tracebacks only in cases where `remove_sentinel` is found. Tracebacks that do not contain the sentinel will be shown as normal, if `test_config.yaml` has `hide_tracebacks` set to `false`.

The `remove_sentinel` can still be used the same way as before if required, only difference is that `hide_tracebacks` doesn't HAVE to be set to `true` in order to use it.

![image](https://user-images.githubusercontent.com/38466145/86137632-298c4080-baf6-11ea-9d59-9a8ae1cb3336.png)
